### PR TITLE
Fix Query String on in URI for async calls

### DIFF
--- a/src/Endpoint.php
+++ b/src/Endpoint.php
@@ -155,6 +155,12 @@ class Endpoint implements EndpointInterface
      */
     private function httpAsync($method, $uri, $options = [])
     {
+        // Attach the query string to the request for ASYNC
+        if (!empty($options['query'])) {
+            $uri .= '?' . $options['query'];
+            unset($options['query']);
+        }
+
         $request = new Request($method, $uri, $options);
 
         Async::addRequest($this->object->getAttribute("oauth"), $request);


### PR DESCRIPTION
The current Async implementation uses Guzzle and PSR7 Objects, which do not take the same signature as a regular Guzzle request. Properly fixing this is beyond the scope of this PR, but this will monkey patch the httpAsync() method to put the query string in the URI before creating the PSR7 Request object, allowing things like resources `.../?page=2` for use with async calls.
